### PR TITLE
Fix org.jenkins-ci.main:maven-plugin:2.7.1

### DIFF
--- a/DotCi-Plugins-Starter-Pack.iml
+++ b/DotCi-Plugins-Starter-Pack.iml
@@ -77,7 +77,7 @@
     <orderEntry type="library" name="Maven: org.mongodb:mongo-java-driver:2.11.0" level="project" />
     <orderEntry type="library" name="Maven: org.mongodb.morphia:morphia:0.107" level="project" />
     <orderEntry type="library" name="Maven: org.objenesis:objenesis:1.2" level="project" />
-    <orderEntry type="library" name="Maven: cglib:cglib-nodep:3.2.0" level="project" />
+    <orderEntry type="library" name="Maven: cglib:cglib-nodep:2.2" level="project" />
     <orderEntry type="library" name="Maven: com.thoughtworks.proxytoys:proxytoys:1.0" level="project" />
     <orderEntry type="library" name="Maven: com.github.fakemongo:fongo:1.3.6" level="project" />
     <orderEntry type="library" name="Maven: com.github.davidmoten:geo:0.6.5" level="project" />
@@ -198,7 +198,7 @@
     <orderEntry type="library" name="Maven: org.apache.ant:ant:1.8.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.ant:ant-launcher:1.8.4" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
-    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-digester:commons-digester:2.1" level="project" />
     <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils:1.8.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.mail:mail:1.4.4" level="project" />

--- a/DotCi-Plugins-Starter-Pack.iml
+++ b/DotCi-Plugins-Starter-Pack.iml
@@ -91,54 +91,49 @@
     <orderEntry type="library" name="Maven: org.tap4j:tap4j:4.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:cobertura:1.9.3" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.main:maven-plugin:2.7.1" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven-agent:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven-interceptor:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.jvnet.hudson:maven2.1-interceptor:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven3-agent:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven3-interceptor:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-core:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-model:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings-builder:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-repository-metadata:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-artifact:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-plugin-api:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-model-builder:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interpolation:1.14" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-utils:2.0.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven-agent:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven-interceptor:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jvnet.hudson:maven2.1-interceptor:1.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven3-agent:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven31-agent:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven3-interceptor:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven31-interceptor:1.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.main.maven:maven3-interceptor-commons:1.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-core:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-model:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-settings-builder:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-repository-metadata:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-artifact:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-plugin-api:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-model-builder:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interpolation:1.16" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-utils:3.0.10" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-component-annotations:1.5.5" level="project" />
     <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-sec-dispatcher:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-compat:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-aether-provider:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven:maven-embedder:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-cipher:1.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-compat:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-aether-provider:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven:maven-embedder:3.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.sonatype.plexus:plexus-cipher:1.7" level="project" />
     <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-api:1.11" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-impl:1.11" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-spi:1.11" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-util:1.11" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.aether:aether-connector-wagon:1.11" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-plexus:2.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-guice:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.sisu:sisu-inject-bean:2.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http-lightweight:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http-shared:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-file:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ftp:1.0-beta-7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http-shared:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http-shared4:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-file:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ftp:2.4" level="project" />
     <orderEntry type="library" name="Maven: commons-net:commons-net:2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh-common:1.0-beta-7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh-common:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interactivity-api:1.0-alpha-6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh-external:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-provider-api:1.0-beta-7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh-external:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-provider-api:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.reporting:maven-reporting-api:3.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.doxia:doxia-sink-api:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-classworlds:2.3" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-classworlds:2.5.1" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.lib:lib-jenkins-maven-artifact-manager:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.lib:lib-jenkins-maven-embedder:3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-webdav-jackrabbit:1.0-beta-7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.jackrabbit:jackrabbit-webdav:1.5.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.jackrabbit:jackrabbit-jcr-commons:1.5.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci.lib:lib-jenkins-maven-embedder:3.11" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-webdav-jackrabbit:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.jackrabbit:jackrabbit-webdav:2.5.2" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: org.slf4j:slf4j-nop:1.5.3" level="project" />
     <orderEntry type="library" name="Maven: net.sourceforge.nekohtml:nekohtml:1.9.13" level="project" />
     <orderEntry type="library" name="Maven: net.sf.trove4j:trove4j:3.0.3" level="project" />

--- a/DotCi-Plugins-Starter-Pack.iml
+++ b/DotCi-Plugins-Starter-Pack.iml
@@ -90,7 +90,7 @@
     <orderEntry type="library" name="Maven: org.tap4j:tap:1.10" level="project" />
     <orderEntry type="library" name="Maven: org.tap4j:tap4j:4.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:cobertura:1.9.3" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.main:maven-plugin:1.424" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci.main:maven-plugin:2.7.1" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven-agent:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.main.maven:maven-interceptor:1.2" level="project" />
     <orderEntry type="library" name="Maven: org.jvnet.hudson:maven2.1-interceptor:1.2" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cobertura</artifactId>
             <version>1.9.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.main</groupId>
+                    <artifactId>maven-plugin</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The upgrade is based on jenkins-1.618 uses
```
wget http://mirrors.jenkins-ci.org/war/1.618/jenkins.war
jar xf jenkins.war ./WEB-INF/plugins/maven-plugin.hpi
jar xf ./WEB-INF/plugins/maven-plugin.hpi META-INF/MANIFEST.MF
cat META-INF/MANIFEST.MF
```

This fix will [later help avoid upgrade issue](https://github.com/groupon/DotCi-Plugins-Starter-Pack/issues/9)
```
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:3.0.1
```

By forcing the use of __com.google.inject:guice:jar:4.0-beta__
because __org.jenkins-ci.main:maven-plugin:2.7.1__
does not import __org.sonatype.sisu:sisu-guice__ as a dependency.
__org.jenkins-ci.main:maven-plugin:1.424__ is wrong version anyway based on jenkins-1.618.
 