### PR TITLE
upgrade to org.apache.httpcomponents:httpclient:4.5.1 by using DotCi-2.27.0

### DIFF
--- a/DotCi-Plugins-Starter-Pack.iml
+++ b/DotCi-Plugins-Starter-Pack.iml
@@ -11,14 +11,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:jacoco:1.0.14" level="project" />
-    <orderEntry type="library" name="Maven: org.jacoco:org.jacoco.report:0.6.2.201302030002" level="project" />
-    <orderEntry type="library" name="Maven: org.jacoco:org.jacoco.core:0.6.2.201302030002" level="project" />
-    <orderEntry type="library" name="Maven: org.ow2.asm:asm-all:4.1" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.kohsuke:asm4:4.0" level="project" />
-    <orderEntry type="library" name="Maven: org.ow2.asm:asm:4.1" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.ow2.asm:asm-commons:4.1" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.ow2.asm:asm-tree:4.1" level="project" />
     <orderEntry type="library" name="Maven: org.jvnet.hudson.plugins:ansicolor:0.3.1" level="project" />
     <orderEntry type="library" name="Maven: org.fusesource.jansi:jansi:1.9" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:build-timeout:1.14" level="project" />
@@ -121,7 +113,7 @@
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-http-shared4:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-file:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ftp:2.4" level="project" />
-    <orderEntry type="library" name="Maven: commons-net:commons-net:2.0" level="project" />
+    <orderEntry type="library" name="Maven: commons-net:commons-net:3.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-ssh-common:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.plexus:plexus-interactivity-api:1.0-alpha-6" level="project" />
@@ -134,7 +126,6 @@
     <orderEntry type="library" name="Maven: org.jenkins-ci.lib:lib-jenkins-maven-embedder:3.11" level="project" />
     <orderEntry type="library" name="Maven: org.apache.maven.wagon:wagon-webdav-jackrabbit:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.jackrabbit:jackrabbit-webdav:2.5.2" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.slf4j:slf4j-nop:1.5.3" level="project" />
     <orderEntry type="library" name="Maven: net.sourceforge.nekohtml:nekohtml:1.9.13" level="project" />
     <orderEntry type="library" name="Maven: net.sf.trove4j:trove4j:3.0.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
@@ -182,7 +173,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ezmorph:ezmorph:1.0.6" level="project" />
     <orderEntry type="library" name="Maven: commons-httpclient:commons-httpclient:3.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: args4j:args4j:2.0.31" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci:annotation-indexer:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci:annotation-indexer:1.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:bytecode-compatibility-transformer:1.5" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:task-reactor:1.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jvnet.localizer:localizer:1.23" level="project" />

--- a/DotCi-Plugins-Starter-Pack.iml
+++ b/DotCi-Plugins-Starter-Pack.iml
@@ -55,7 +55,7 @@
     <orderEntry type="library" name="Maven: org.jvnet.hudson.plugins:analysis-core:1.73" level="project" />
     <orderEntry type="library" name="Maven: de.java2html:java2html:5.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
-    <orderEntry type="library" name="Maven: com.groupon.jenkins-ci.plugins:DotCi:2.24.3" level="project" />
+    <orderEntry type="library" name="Maven: com.groupon.jenkins-ci.plugins:DotCi:2.27.0" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:github-api:1.68" level="project" />
     <orderEntry type="library" name="Maven: org.kohsuke:github-api:1.68" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.2.3" level="project" />
@@ -72,8 +72,8 @@
     <orderEntry type="library" name="Maven: net.jcip:jcip-annotations:1.0" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:ssh-credentials:1.6.1" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:scm-api:0.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.3" level="project" />
     <orderEntry type="library" name="Maven: org.mongodb:mongo-java-driver:2.11.0" level="project" />
     <orderEntry type="library" name="Maven: org.mongodb.morphia:morphia:0.107" level="project" />
     <orderEntry type="library" name="Maven: org.objenesis:objenesis:1.2" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>com.groupon.jenkins-ci.plugins</groupId>
             <artifactId>DotCi</artifactId>
-            <version>2.24.3</version>
+            <version>2.27.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
necessary later to upgrade to jenkins-1.641 where testing requires  org.apache.http.cookie.CookieSpecProvider 

see https://github.com/groupon/DotCi/pull/213 for explanation