### PR TITLE
migrate to com.groupon.jenkins-ci.plugins:DotCi-Plugins-Starter-Pack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <artifactId>plugin</artifactId>
         <version>1.618</version>
     </parent>
-    <groupId>com.groupon.jenkins.plugins</groupId>
+    <groupId>com.groupon.jenkins-ci.plugins</groupId>
     <artifactId>DotCi-Plugins-Starter-Pack</artifactId>
     <version>1.7.2-SNAPSHOT</version>
     <packaging>hpi</packaging>


### PR DESCRIPTION
publish from http://repo.jenkins-ci.org/releases/com/groupon/jenkins/plugins
to http://repo.jenkins-ci.org/releases/com/groupon/jenkins-ci/plugins like rest of DotCi plugins

to fix #12 