### PR TITLE
Allow cobertura plugin to be configured for coverage XML files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y -q build-essential && \
   rm -rf /var/lib/apt/lists/*
 
 # Installs Ant
-ENV ANT_VERSION=1.9.6 ANT_HOME=/opt/ant PATH=${PATH}:/opt/ant/bin
+ENV ANT_VERSION=1.9.7 ANT_HOME=/opt/ant PATH=${PATH}:/opt/ant/bin
 RUN cd && \
-    wget -q http://www.us.apache.org/dist//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    wget http://www.us.apache.org/dist//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
     tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz && \
     mv apache-ant-${ANT_VERSION} ${ANT_HOME} && \
     rm apache-ant-${ANT_VERSION}-bin.tar.gz

--- a/README.md
+++ b/README.md
@@ -23,25 +23,26 @@ Extends [DotCi](https://github.com/groupon/DotCi) in the following ways
     ```
 - Add the following plugins
 
- ```yaml
+  ```yaml
    plugins:
   - junit #defaults to '**/surefire-reports/*.xml', can configure
   - tap
   - checkstyle #expects file to be target/checkstyle-result.xml
-  - cobertura #expects target/site/cobertura/coverage.xml
+  - cobertura #expects 'target/site/cobertura/coverage.xml', can configure
   - findbugs #expects target/findbugsXml.xml
   - jacoco  # expects **/jacoco.exec
   - pmd #expects **/pmd.xml
   ```
 
 Please take a look at [pom.xml](/pom.xml) for full list of plugin dependencies.
-##Installation
+
+## Installation
 Install the plugin from Jenkins Update Center under `Manage Jenkins > Manage Plugins`
 
-##Development Setup
- Please see [DotCi Development Setup](https://github.com/groupon/DotCi/blob/master/docs/DevelopmentSetup.md)
+## Development Setup
+Please see [DotCi Development Setup](https://github.com/groupon/DotCi/blob/master/docs/DevelopmentSetup.md)
 
-##LICENSE
+## LICENSE
 ```
 The MIT License (MIT)
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cobertura</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.main</groupId>

--- a/src/main/java/com/groupon/jenkins/dotci/plugins/CoberturaPluginAdapter.java
+++ b/src/main/java/com/groupon/jenkins/dotci/plugins/CoberturaPluginAdapter.java
@@ -32,7 +32,7 @@ import hudson.model.BuildListener;
 import hudson.plugins.cobertura.CoberturaPublisher;
 
 @Extension
-public class CoberturaPluginAdapter extends DotCiPluginAdapter {
+public class CoberturaPluginAdapter extends FileBasedPluginAdapter {
 
     public CoberturaPluginAdapter() {
         super("cobertura", "target/site/cobertura/coverage.xml");

--- a/src/main/java/com/groupon/jenkins/dotci/plugins/FileBasedPluginAdapter.java
+++ b/src/main/java/com/groupon/jenkins/dotci/plugins/FileBasedPluginAdapter.java
@@ -24,40 +24,47 @@
 package com.groupon.jenkins.dotci.plugins;
 
 import com.groupon.jenkins.buildtype.plugins.DotCiPluginAdapter;
-import com.groupon.jenkins.dynamic.build.DynamicBuild;
-import hudson.Extension;
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Descriptor;
-import hudson.model.Saveable;
-import hudson.tasks.junit.JUnitResultArchiver;
-import hudson.tasks.junit.TestDataPublisher;
-import hudson.util.DescribableList;
 
 import com.google.common.base.Joiner;
 
 import java.util.List;
 
-@Extension
-public class JunitPluginAdapter extends FileBasedPluginAdapter {
-
-  public JunitPluginAdapter() {
-    super("junit", "**/surefire-reports/*.xml");
+public abstract class FileBasedPluginAdapter extends DotCiPluginAdapter {
+  protected FileBasedPluginAdapter(String name, String pluginInputFiles) {
+    super(name, pluginInputFiles);
   }
 
-  @Override
-  public boolean perform(DynamicBuild dynamicBuild, Launcher launcher, BuildListener listener) {
-    String files = getPluginInputFiles();
-    listener.getLogger().println(String.format("Archiving JUnit results: '%s'", files));
+  protected FileBasedPluginAdapter(String name) {
+    super(name);
+  }
 
-    DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>> testDataPublishers = new DescribableList<TestDataPublisher, Descriptor<TestDataPublisher>>(Saveable.NOOP);
-    JUnitResultArchiver publisher = new JUnitResultArchiver(files, true, testDataPublishers);
-    try {
-      return publisher.perform(((AbstractBuild) dynamicBuild), launcher, listener);
-    } catch (Exception e) {
-      listener.getLogger().println(String.format("FAILED archiving JUnit results: %s", e.toString()));
-      return false;
+  // Example with junit
+  //
+  // plugins:
+  //   - junit
+  //
+  // OR
+  //
+  // plugins:
+  //   - junit: "**/dir1/*.ext1,dir2/*.ext2"
+  //
+  // OR
+  //
+  // plugins:
+  //   - junit:
+  //     - **/dir1/*.ext1
+  //     - dir2/*.ext2
+  //
+  @Override
+  public String getPluginInputFiles() {
+    // If we have options override pluginInputFiles potentially
+    if (options instanceof String) {
+      // options is string, just return
+      return (String)options;
+    } else if (options instanceof List) {
+      return Joiner.on(",").join((List)options);
+    } else {
+      return pluginInputFiles;
     }
   }
 }

--- a/src/test/java/com/groupon/jenkins/dotci/plugins/CoberturaPluginAdapterTest.java
+++ b/src/test/java/com/groupon/jenkins/dotci/plugins/CoberturaPluginAdapterTest.java
@@ -1,0 +1,39 @@
+package com.groupon.jenkins.dotci.plugins;
+
+import com.google.common.collect.ImmutableList;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+  CoberturaPluginAdapterTest.getPluginInputFiles.class
+})
+public class CoberturaPluginAdapterTest {
+  public static class getPluginInputFiles {
+    @Test
+    public void should_return_file_with_default() {
+      CoberturaPluginAdapter subject = new CoberturaPluginAdapter();
+      assertEquals(subject.getPluginInputFiles(), "target/site/cobertura/coverage.xml");
+    }
+
+    @Test
+    public void should_return_files_with_string() {
+      CoberturaPluginAdapter subject = new CoberturaPluginAdapter();
+      subject.setOptions("file1,file2,file3");
+      assertEquals(subject.getPluginInputFiles(), "file1,file2,file3");
+    }
+
+    @Test
+    public void should_return_files_with_list() {
+      CoberturaPluginAdapter subject = new CoberturaPluginAdapter();
+      subject.setOptions(ImmutableList.of("file1", "file2", "file3"));
+      assertEquals(subject.getPluginInputFiles(), "file1,file2,file3");
+    }
+  }
+}
+


### PR DESCRIPTION
Mimics https://github.com/groupon/DotCi-Plugins-Starter-Pack/pull/8 but for cobertura. Started abstracting this configuration ability into a base class, might consider applying to all the other plugins where it makes sense.
```
  // plugins:
  //   - cobertura
  //
  // OR
  //
  // plugins:
  //   - cobertura: "**/dir1/*.ext1,dir2/*.ext2"
  //
  // OR
  //
  // plugins:
  //   - cobertura:
  //     - **/dir1/*.ext1
  //     - dir2/*.ext2
  //
```